### PR TITLE
Add secondary user locale (region) to string lookup

### DIFF
--- a/AuthenticatorChooser/Startup.cs
+++ b/AuthenticatorChooser/Startup.cs
@@ -55,7 +55,7 @@ public class Startup {
                     logger.Info("{name} {version} starting", PROGRAM_NAME, PROGRAM_VERSION);
                     (string name, string marketingVersion, Version version, string arch) os = getOsVersion();
                     logger.Info("Operating system is {name} {marketingVersion} {version} {arch}", os.name, os.marketingVersion, os.version, os.arch);
-                    logger.Info("Locales are {userLocale} (user) and {systemLocale} (system)", I18N.userLocaleName, I18N.systemLocaleName);
+                    logger.Info("Locales are {userUiLocale} (user UI), {userLocale} (user) and {systemLocale} (system)", I18N.userUiLocaleName, I18N.userLocaleName, I18N.systemLocaleName);
 
                     using WindowOpeningListener windowOpeningListener = new WindowOpeningListenerImpl();
                     windowOpeningListener.windowOpened += (_, window) => SecurityKeyChooser.chooseUsbSecurityKey(window);


### PR DESCRIPTION
On my system (24H2) I have a combination of en-US and de-DE locales. I use en-US as UI locale, but de-DE is configured as a "region" for date/time formatting etc. Some dialogs (including the credential dialog) seem to choose their language based on the incorrect locale (de-DE). AuthenticatorChooser would choose the wrong strings in this case (en-US) and not do anything in the dialog.

This PR changes string lookup so that strings for the secondary locale are also looked up.

For the record, this is what the dialog looks like for me:

![image](https://github.com/user-attachments/assets/a461f873-909e-4abe-835d-fcb9ff248cb3)
