### PR TITLE
feat: add system tray icon with enable/disable toggle and exit option

### DIFF
--- a/AuthenticatorChooser/Startup.cs
+++ b/AuthenticatorChooser/Startup.cs
@@ -90,8 +90,9 @@ public class Startup {
                 logger.Info("Operating system is {name} {marketingVersion} {version} {arch}", os.name, os.marketingVersion, os.version, os.architecture);
                 logger.Info("{Locales are} {locales}", I18N.LOCALE_NAMES.Count == 1 ? "Locale is" : "Locales are", string.Join(", ", I18N.LOCALE_NAMES));
 
+                using TrayIcon              trayIcon              = new TrayIcon(() => { EXITING_TRIGGER.Cancel(); Application.Exit(); });
                 using WindowOpeningListener windowOpeningListener = new WindowOpeningListenerImpl();
-                WindowsSecurityKeyChooser   securityKeyChooser    = new(new ChooserOptions(skipAllNonSecurityKeyOptions, autosubmitPinLength));
+                WindowsSecurityKeyChooser   securityKeyChooser    = new(new ChooserOptions(skipAllNonSecurityKeyOptions, autosubmitPinLength), trayIcon);
 
                 windowOpeningListener.windowOpened += (_, window) => securityKeyChooser.chooseUsbSecurityKey(window);
 

--- a/AuthenticatorChooser/TrayIcon.cs
+++ b/AuthenticatorChooser/TrayIcon.cs
@@ -1,0 +1,41 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace AuthenticatorChooser;
+
+public class TrayIcon: IDisposable {
+
+    private readonly NotifyIcon       notifyIcon;
+    private readonly ToolStripMenuItem enabledMenuItem;
+
+    public bool isEnabled => enabledMenuItem.Checked;
+
+    public TrayIcon(Action onExit) {
+        enabledMenuItem = new ToolStripMenuItem("Enabled") {
+            Checked     = true,
+            CheckOnClick = true
+        };
+
+        ToolStripMenuItem exitMenuItem = new("Exit");
+        exitMenuItem.Click += (_, _) => onExit();
+
+        ContextMenuStrip contextMenu = new();
+        contextMenu.Items.Add(enabledMenuItem);
+        contextMenu.Items.Add(new ToolStripSeparator());
+        contextMenu.Items.Add(exitMenuItem);
+
+        notifyIcon = new NotifyIcon {
+            Text             = nameof(AuthenticatorChooser),
+            Icon             = Icon.ExtractAssociatedIcon(Environment.ProcessPath!)!,
+            ContextMenuStrip = contextMenu,
+            Visible          = true
+        };
+    }
+
+    public void Dispose() {
+        notifyIcon.Visible = false;
+        notifyIcon.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+}

--- a/AuthenticatorChooser/Windows11/WindowsSecurityKeyChooser.cs
+++ b/AuthenticatorChooser/Windows11/WindowsSecurityKeyChooser.cs
@@ -7,7 +7,7 @@ using Unfucked;
 
 namespace AuthenticatorChooser.Windows11;
 
-public class WindowsSecurityKeyChooser(ChooserOptions options): AbstractSecurityKeyChooser<SystemWindow> {
+public class WindowsSecurityKeyChooser(ChooserOptions options, TrayIcon trayIcon): AbstractSecurityKeyChooser<SystemWindow> {
 
     // #4: unfortunately, this class name is shared with the UAC prompt, detectable when desktop dimming is disabled
     private const string WINDOW_CLASS_NAME  = "Credential Dialog Xaml Host";
@@ -71,7 +71,7 @@ public class WindowsSecurityKeyChooser(ChooserOptions options): AbstractSecurity
 
             bool isShiftDown = Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift);
 
-            strategy.handleWindow(actualTitle!, fidoEl, outerScrollViewer, isShiftDown);
+            strategy.handleWindow(actualTitle!, fidoEl, outerScrollViewer, isShiftDown || !trayIcon.isEnabled);
 
         } catch (ElementNotAvailableException e) {
             LOGGER.Error(e, "Element in Windows Security dialog box disappeared before this program could interact with it, skipping this dialog box instance");


### PR DESCRIPTION
Had a couple of minutes and threw this together - would need to be updated in documentation as well of course. Result is the following and uses the same methodology with <kbd>SHIFT</kbd> - here using the enabled/disabled toggle. Using the same icon as the app icon.

Screenshot:
<img width="179" height="120" alt="image" src="https://github.com/user-attachments/assets/c18ea85d-3928-4aa2-b507-c28e235ac40e" />


implements: https://github.com/Aldaviva/AuthenticatorChooser/issues/57